### PR TITLE
add index GloBI index configuration

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,27 @@
+# This workflow will review a GloBI indexed dataset.
+# For more information see: https://globalbioticinteractions.org
+
+name: GloBI review by Elton
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+  schedule:
+    - cron: "0 0 * * 1"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: download review script
+      run: curl --silent -L "https://raw.githubusercontent.com/globalbioticinteractions/globinizer/master/check-dataset.sh" > check-dataset.sh
+    - name: review dataset
+      run: bash check-dataset.sh "${GITHUB_REPOSITORY}" 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+datasets/

--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ Darwin core archives have emerged as the accepted data-sharing standard for occu
 ### Citations
 
 Yoder, M.J., Dole, K., Seltmann, K., and Deans, A. 2006-Present. Mx, a collaborative web based content management for biological systematists. http://mx.phenomix.org/index.php/Main_Page
+
+### Indexing 
+
+[![GloBI review by Elton](https://github.com/Seltmann/taxonomy-darwin-core/actions/workflows/review.yml/badge.svg)](https://github.com/Seltmann/taxonomy-darwin-core/actions) [![GloBI](https://api.globalbioticinteractions.org/interaction.svg?accordingTo=globi:Seltmann/taxonomy-darwin-core)](https://globalbioticinteractions.org/?accordingTo=globi:Seltmann/taxonomy-darwin-core) 
+
+This publications is configured to be indexed by Global Biotic Interactions (GloBI, https://globalbioticinteractions.org). 

--- a/globi.json
+++ b/globi.json
@@ -1,0 +1,4 @@
+{ 
+  "format": "dwca",
+  "shouldResolveReferences": false
+}

--- a/interaction_types_mapping.csv
+++ b/interaction_types_mapping.csv
@@ -1,0 +1,3 @@
+provided_interaction_type_label,provided_interaction_type_id,mapped_to_interaction_type_label,mapped_to_interaction_type_id
+host of,,hostOf,http://purl.obolibrary.org/obo/RO_0002453
+parasitoid of,,parasitoidOf,http://purl.obolibrary.org/obo/RO_0002208


### PR DESCRIPTION
Hi @seltmann - 

In https://github.com/globalbioticinteractions/globalbioticinteractions/issues/744 , you expressed a desire to have your publication:

 Seltmann KC (2021) Seltmann/taxonomy-darwin-core: Darwin Core Formatted Occurrence Data for Taxonomic Studies (v1.0). Zenodo https://doi.org/10.5281/zenodo.5745963

be indexed by GloBI.

In this pull request, I've added minimal index configuration to your repository, so that folks cloning your repo will get the functionality for free. 

Please let me know if you have concerns. Otherwise, please accept this pull request to get your data indexed.

Hope this helps,
-jorrit