### PR TITLE
globi.json no longer needed for DwC-A repositories with eml.xml 

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -12,16 +12,30 @@ on:
     - cron: "0 0 * * 1"
 
 jobs:
-  build:
+  review:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        distribution: 'temurin' 
+        java-version: '8'   
     - name: download review script
       run: curl --silent -L "https://raw.githubusercontent.com/globalbioticinteractions/globinizer/master/check-dataset.sh" > check-dataset.sh
+    - name: download network compiler script
+      run: |
+        curl --silent -L "https://raw.githubusercontent.com/globalbioticinteractions/globinizer/master/compile-network.sh" > compile-network.sh
+        chmod +x compile-network.sh
     - name: review dataset
       run: bash check-dataset.sh "${GITHUB_REPOSITORY}" 
+    - name: Share review report
+      uses: actions/upload-artifact@v3
+      with:
+        name: review-report
+        path: |
+          README.txt
+          datasets/ 
+          index.*
+          indexed-* 
+          review* 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,6 @@ Darwin core archives have emerged as the accepted data-sharing standard for occu
 Yoder, M.J., Dole, K., Seltmann, K., and Deans, A. 2006-Present. Mx, a collaborative web based content management for biological systematists. http://mx.phenomix.org/index.php/Main_Page
 
 ### Indexing 
-![GloBI Review by Elton](../../actions/workflows/review.yml/badge.svg)](../../actions/workflows/review.yml) [![GloBI](https://api.globalbioticinteractions.org/interaction.svg?accordingTo=globi:seltmann/taxonomy-darwin-core)](https://globalbioticinteractions.org/?accordingTo=globi:seltmann/taxonomy-darwin-core) 
+[![GloBI Review by Elton](../../actions/workflows/review.yml/badge.svg)](../../actions/workflows/review.yml) [![GloBI](https://api.globalbioticinteractions.org/interaction.svg?accordingTo=globi:seltmann/taxonomy-darwin-core)](https://globalbioticinteractions.org/?accordingTo=globi:seltmann/taxonomy-darwin-core) 
 
 This publications is configured to be indexed by Global Biotic Interactions (GloBI, https://globalbioticinteractions.org). 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Darwin core archives have emerged as the accepted data-sharing standard for occu
 Yoder, M.J., Dole, K., Seltmann, K., and Deans, A. 2006-Present. Mx, a collaborative web based content management for biological systematists. http://mx.phenomix.org/index.php/Main_Page
 
 ### Indexing 
-
-[![GloBI review by Elton](https://github.com/Seltmann/taxonomy-darwin-core/actions/workflows/review.yml/badge.svg)](https://github.com/Seltmann/taxonomy-darwin-core/actions) [![GloBI](https://api.globalbioticinteractions.org/interaction.svg?accordingTo=globi:Seltmann/taxonomy-darwin-core)](https://globalbioticinteractions.org/?accordingTo=globi:Seltmann/taxonomy-darwin-core) 
+![GloBI Review by Elton](../../actions/workflows/review.yml/badge.svg)](../../actions/workflows/review.yml) [![GloBI](https://api.globalbioticinteractions.org/interaction.svg?accordingTo=globi:seltmann/taxonomy-darwin-core)](https://globalbioticinteractions.org/?accordingTo=globi:seltmann/taxonomy-darwin-core) 
 
 This publications is configured to be indexed by Global Biotic Interactions (GloBI, https://globalbioticinteractions.org). 

--- a/globi.json
+++ b/globi.json
@@ -1,3 +1,0 @@
-{ 
-  "format": "dwca"
-}


### PR DESCRIPTION
Hey @seltmann - Just wanted to let you know that globi.json files are no longer needed to have GloBI index DwC repositories. However, a mention of globalbioticinteractions.org is needed in the README.md . 

Please accept this pull request to remove globi.json from taxonomy-darwin-core and update your review workflow definition.